### PR TITLE
Fix issue with adding a custom site url too early

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}</title>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,600">
-    <link href="{{ site.url }}/resources/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="{{ site.url }}/style.css">
+    <link href="{{ site.baseurl }}/resources/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ site.baseurl }}/style.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for {{ site.name }}" href="{{ site.baseurl }}/feed.xml" />
 </head>


### PR DESCRIPTION
If site and resources have not yet been published, then referencing {{ site.url }}/style.scss will fail, and the site will build incorrectly. Since adding a custom url is a step specifically mentioned in the README's configuration section, it is highly likely to be edited before first publication, causing it to appear to be broken. 